### PR TITLE
Limit expansion when size is reduced

### DIFF
--- a/draft-thomson-tls-record-limit.md
+++ b/draft-thomson-tls-record-limit.md
@@ -173,14 +173,15 @@ of a protected record that contains the maximum amount of plaintext and the
 minimum permitted amount of padding.
 
 For example, TLS_RSA_WITH_AES_128_CBC_SHA has 16 octet blocks and a 20 octet
-MAC.  Given a record size limit of 256, a record of that length would require 11
-octets of padding (for {{!RFC5246}} where the MAC is covered by encryption); or
-15 octets if the `encrypt_then_mac` extension {{!RFC7366}} is negotiated.  A
-record with 250 octets of plaintext could be padded to the same length by
-including 17 octets of padding; or 21 octets with `encrypt_then_mac`.
+MAC.  Given a record size limit of 256, a record of that length would require a
+minimum of 11 octets of padding (for {{!RFC5246}} where the MAC is covered by
+encryption); or 15 octets if the `encrypt_then_mac` extension {{!RFC7366}} is
+negotiated.  With this limit, a record with 250 octets of plaintext could be
+padded to the same length by including at most 17 octets of padding; or 21
+octets with `encrypt_then_mac`.
 
-An implementation that always adds the minimum amount of padding to records
-protected with block ciphers will always comply with this requirement.
+An implementation that always adds the minimum amount of padding will always
+comply with this requirement.
 
 
 # Deprecating "max_fragment_length"


### PR DESCRIPTION
The idea of this change is to try to constrain how much padding
a sender can add.  This is done by calculating the size of a
record with maximum plaintext and minimum padding.  No other record
can exceed this size, though smaller packets can pad to reach this
size.

I was going to include a formula, then realized that the simple
answer is best: pad to the record size limit, then pad to get
to a multiple of the block size as normal.  Most implementations
will be OK because they don't bother with the first step.