### PR TITLE
Relationship with other constraints on implementations

### DIFF
--- a/draft-ietf-tls-record-limit.md
+++ b/draft-ietf-tls-record-limit.md
@@ -56,14 +56,14 @@ The `max_fragment_length` extension {{?RFC6066}} was designed to enable
 constrained clients to negotiate a lower record size.  However,
 `max_fragment_length` suffers from several design problems (see {{mfl-bad}}).
 
-A smaller protected record size is just one of many problems that a constrained
-implementation might need to address.  The `max_fragment_length` extension only
-addresses the memory allocation problem, it does not address limits of code
-size, or processing and bandwidth capacity.
-
 This document defines a `record_size_limit` extension ({{max-record}}).  This
 extension replaces `max_fragment_length` {{!RFC6066}}, which this document
 deprecates.  This extension is valid in all versions of TLS.
+
+A smaller protected record size is just one of many problems that a constrained
+implementation might need to address.  The `record_size_limit` extension only
+addresses the memory allocation problem, it does not address limits of code
+size, or processing and bandwidth capacity.
 
 
 # Conventions and Definitions
@@ -127,8 +127,7 @@ The ExtensionData of the `record_size_limit` extension is RecordSizeLimit:
 The value of RecordSizeLimit is the maximum size of record in octets that the
 endpoint is willing to receive.  This value is used to limit the size of records
 that are created when encoding application data and protected handshake message
-into records.  The limit can interact with the maximum transfer unit (MTU) in
-DTLS, but it is a separate and independent constraint on record sizes.
+into records.
 
 When the `record_size_limit` extension is negotiated, an endpoint MUST NOT
 generate a protected record with plaintext that is larger than the
@@ -175,6 +174,13 @@ Records are subject to the limits that were set in the handshake that produces
 the keys that are used to protect those records.  This admits the possibility
 that the extension might not be negotiated when a connection is renegotiated or
 resumed.
+
+The record size limit can interact with the maximum transmission unit (MTU)
+in DTLS, but it is a separate and independent constraint on record size.  In
+particular, it is not appropriate to use the record size limit in place of path
+MTU detection.  The record size limit is a fixed property of an endpoint that
+is set during the handshake and fixed thereafter.  In comparison, the MTU is
+determined by the network path and can change dynamically over time.
 
 
 ## Record Expansion Limits {#expansion}

--- a/draft-ietf-tls-record-limit.md
+++ b/draft-ietf-tls-record-limit.md
@@ -56,6 +56,11 @@ The `max_fragment_length` extension {{?RFC6066}} was designed to enable
 constrained clients to negotiate a lower record size.  However,
 `max_fragment_length` suffers from several design problems (see {{mfl-bad}}).
 
+A smaller protected record size is just one of many problems that a constrained
+implementation might need to address.  The `max_fragment_length` extension only
+addresses the memory allocation problem, it does not address limits of code
+size, or processing and bandwidth capacity.
+
 This document defines a `record_size_limit` extension ({{max-record}}).  This
 extension replaces `max_fragment_length` {{!RFC6066}}, which this document
 deprecates.  This extension is valid in all versions of TLS.
@@ -122,7 +127,8 @@ The ExtensionData of the `record_size_limit` extension is RecordSizeLimit:
 The value of RecordSizeLimit is the maximum size of record in octets that the
 endpoint is willing to receive.  This value is used to limit the size of records
 that are created when encoding application data and protected handshake message
-into records.
+into records.  The limit can interact with the maximum transfer unit (MTU) in
+DTLS, but it is a separate and independent constraint on record sizes.
 
 When the `record_size_limit` extension is negotiated, an endpoint MUST NOT
 generate a protected record with plaintext that is larger than the


### PR DESCRIPTION
Add an applicability statement.  This only addresses buffer space issues, not
processing or bandwidth constraints.  I didn't observe (in the introduction)
that this can negatively affect bandwidth, that's later.

Hannes also observed that we don't really talk about the path MTU.  I made it
clear that these are separate and independent limitations.

For @hannestschofenig